### PR TITLE
Fix navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,24 +2,24 @@
 # pages in order as they should show up.
 main:
   - title: "About"
-    url: /about
+    url: /about/
   - title: "Projects"
-    url: /index.html#Projects
+    url: /#Projects
 
 toggle:
   - title: "Blog"
-    url: /blog
+    url: /blog/
 
 subnav:
   - title: "Archives"
-    url: /archive
+    url: /archive/
 
 mobile:
   - title: "About"
-    url: /about
+    url: /about/
   - title: "Projects"
-    url: /index.html#Projects
+    url: /#Projects
   - title: "Blog"
-    url: /blog
+    url: /blog/
   - title: "Archive"
-    url: /archive
+    url: /archive/


### PR DESCRIPTION
This PR fixes the following two issues;

1. Currently, all your navigation URLs are missing a forward slash. 
This causes an unnecessary redirect when you click on a nav link. 
For example `/blog` will redirect to `/blog/`, it works but it takes longer. 

2. I removed `index.html` from both Projects URLs. This wasn't necessary for the link to work correctly.